### PR TITLE
Fix RMMapView adjustedZoomForRetinaDisplay calculation, which was causin...

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -2634,10 +2634,11 @@
 
 - (float)adjustedZoomForRetinaDisplay
 {
-    if (!self.adjustTilesForRetinaDisplay && _screenScale > 1.0 && ! [RMMapboxSource isUsingLargeTiles])
-        return [self zoom] + 1.0;
+    if (!self.adjustTilesForRetinaDisplay && self.screenScale > 1.0 && [RMMapboxSource isUsingLargeTiles]) {
+        return fminf(self.tileSourcesMaxZoom, self.zoom + 1.0);
+    }
 
-    return [self zoom];
+    return self.zoom;
 }
 
 - (RMProjection *)projection


### PR DESCRIPTION
...g map snapshot to render tiles at incorrect zoom level.

Upstream mapbox issue: https://github.com/mapbox/mapbox-ios-sdk/issues/589
