### PR TITLE
Clear scroll view delegate on dealloc

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -477,6 +477,7 @@
     _locationManager.delegate = nil;
     [_locationManager stopUpdatingLocation];
     [_locationManager stopUpdatingHeading];
+    _mapScrollView.delegate = nil; // UIScrollView's delegate is not weak
 }
 
 - (void)didReceiveMemoryWarning


### PR DESCRIPTION
`UIScrollView`'s delegate isn't weak so we need to explicitly clear it when the map view is deallocated. Only seeing this crash in unit tests, but this stops it.
