### PR TITLE
Add cachedImageForTile:inCache: to RMTileSource. 

### DIFF
--- a/MapView/Map/RMAbstractMercatorTileSource.m
+++ b/MapView/Map/RMAbstractMercatorTileSource.m
@@ -68,7 +68,7 @@
 
 - (UIImage *)cachedImageForTile:(RMTile)tile inCache:(RMTileCache *)tileCache {
     NSLog(@"Warning: Tile source: %@ does not implement cachedImageForTile:inCache:", self.description);
-    return (UIImage *)[NSNull null];
+    return nil;
 }
 
 - (BOOL)tileSourceHasTile:(RMTile)tile

--- a/MapView/Map/RMAbstractMercatorTileSource.m
+++ b/MapView/Map/RMAbstractMercatorTileSource.m
@@ -64,7 +64,12 @@
     @throw [NSException exceptionWithName:@"RMAbstractMethodInvocation"
                                    reason:@"imageForTile:inCache: invoked on RMAbstractMercatorTileSource. Override this method when instantiating an abstract class."
                                  userInfo:nil];
-}    
+}
+
+- (UIImage *)cachedImageForTile:(RMTile)tile inCache:(RMTileCache *)tileCache {
+    NSLog(@"Warning: Tile source: %@ does not implement cachedImageForTile:inCache:", self.description);
+    return (UIImage *)[NSNull null];
+}
 
 - (BOOL)tileSourceHasTile:(RMTile)tile
 {

--- a/MapView/Map/RMAbstractWebMapSource.h
+++ b/MapView/Map/RMAbstractWebMapSource.h
@@ -62,7 +62,7 @@
  *
  *  @param tile The tile required
  *
- *  @return UIImage if the tile is cached, NSNULL if not.
+ *  @return UIImage if the tile is cached, nil if not.
  */
 -(UIImage *)cachedImageForTile:(RMTile)tile;
 

--- a/MapView/Map/RMAbstractWebMapSource.h
+++ b/MapView/Map/RMAbstractWebMapSource.h
@@ -54,4 +54,16 @@
     @return An array of tile URLs to download, listed bottom to top. */
 - (NSArray *)URLsForTile:(RMTile)tile;
 
+/**
+ *  Returns the tile image if it is already cached. This method *does not* make 
+ *  a network request if the tile image isn't already downloaded.
+ *  This is useful for map snapshotting if we don't want to fire off network 
+ *  requests as a side effect of rendering the current map view.
+ *
+ *  @param tile The tile required
+ *
+ *  @return UIImage if the tile is cached, NSNULL if not.
+ */
+-(UIImage *)cachedImageForTile:(RMTile)tile;
+
 @end

--- a/MapView/Map/RMAbstractWebMapSource.m
+++ b/MapView/Map/RMAbstractWebMapSource.m
@@ -64,10 +64,10 @@
 
     RMTile normalisedTile = [[self mercatorToTileProjection] normaliseTile:tile];
 
-    // Return NSNull here so that the RMMapTiledLayerView will try to
+    // Return nil here so that the RMMapTiledLayerView will try to
     // fetch another tile if missingTilesDepth > 0
     if ( ! [self tileSourceHasTile:normalisedTile])
-    return (UIImage *)[NSNull null];
+        return nil;
 
     if (self.isCacheable)
     {

--- a/MapView/Map/RMAbstractWebMapSource.m
+++ b/MapView/Map/RMAbstractWebMapSource.m
@@ -77,7 +77,7 @@
             return image;
         }
     }
-    return (UIImage *)[NSNull null];
+    return nil;
 }
 
 - (UIImage *)imageForTile:(RMTile)tile inCache:(RMTileCache *)tileCache

--- a/MapView/Map/RMAbstractWebMapSource.m
+++ b/MapView/Map/RMAbstractWebMapSource.m
@@ -59,6 +59,27 @@
     return [NSArray arrayWithObjects:[self URLForTile:tile], nil];
 }
 
+-(UIImage *)cachedImageForTile:(RMTile)tile inCache:(RMTileCache *)tileCache {
+    __block UIImage *image = nil;
+
+    RMTile normalisedTile = [[self mercatorToTileProjection] normaliseTile:tile];
+
+    // Return NSNull here so that the RMMapTiledLayerView will try to
+    // fetch another tile if missingTilesDepth > 0
+    if ( ! [self tileSourceHasTile:normalisedTile])
+    return (UIImage *)[NSNull null];
+
+    if (self.isCacheable)
+    {
+        image = [tileCache cachedImage:normalisedTile withCacheKey:[self uniqueTilecacheKey]];
+        
+        if (image) {
+            return image;
+        }
+    }
+    return (UIImage *)[NSNull null];
+}
+
 - (UIImage *)imageForTile:(RMTile)tile inCache:(RMTileCache *)tileCache
 {
     __block UIImage *image = nil;

--- a/MapView/Map/RMMapTiledLayerView.m
+++ b/MapView/Map/RMMapTiledLayerView.m
@@ -123,7 +123,7 @@
                     UIImage *tileImage = [_tileSource cachedImageForTile:tile inCache:[_mapView tileCache]];
 
                     // If this tile's image is not present, try to obtain lower resolution tiles from higher zoom levels instead.
-                    if (tileImage == (id)[NSNull null])
+                    if (!tileImage)
                     {
                         if (_mapView.missingTilesDepth == 0)
                         {
@@ -133,7 +133,7 @@
                         {
                             NSUInteger currentTileDepth = 1, currentZoom = zoom - currentTileDepth;
                             
-                            while ((tileImage== (id)[NSNull null]) && currentZoom >= _tileSource.minZoom && currentTileDepth <= _mapView.missingTilesDepth)
+                            while (!tileImage && currentZoom >= _tileSource.minZoom && currentTileDepth <= _mapView.missingTilesDepth)
                             {
                                 float nextX = x / powf(2.0, (float)currentTileDepth),
                                 nextY = y / powf(2.0, (float)currentTileDepth);

--- a/MapView/Map/RMMapTiledLayerView.m
+++ b/MapView/Map/RMMapTiledLayerView.m
@@ -119,10 +119,60 @@
             {
                 for (int y=y1; y<=y2; ++y)
                 {
-                    UIImage *tileImage = [_tileSource imageForTile:RMTileMake(x, y, zoom) inCache:[_mapView tileCache]];
+                    RMTile tile = RMTileMake(x, y, zoom);
+                    UIImage *tileImage = [_tileSource cachedImageForTile:tile inCache:[_mapView tileCache]];
 
-                    if (IS_VALID_TILE_IMAGE(tileImage))
+                    // If this tile's image is not present, try to obtain lower resolution tiles from higher zoom levels instead.
+                    if (tileImage == (id)[NSNull null])
+                    {
+                        if (_mapView.missingTilesDepth == 0)
+                        {
+                            tileImage = [RMTileImage errorTile];
+                        }
+                        else
+                        {
+                            NSUInteger currentTileDepth = 1, currentZoom = zoom - currentTileDepth;
+                            
+                            while ((tileImage== (id)[NSNull null]) && currentZoom >= _tileSource.minZoom && currentTileDepth <= _mapView.missingTilesDepth)
+                            {
+                                float nextX = x / powf(2.0, (float)currentTileDepth),
+                                nextY = y / powf(2.0, (float)currentTileDepth);
+                                float nextTileX = floor(nextX),
+                                nextTileY = floor(nextY);
+                                
+                                tileImage = [_tileSource cachedImageForTile:RMTileMake((int)nextTileX, (int)nextTileY, currentZoom)
+                                                                    inCache:[_mapView tileCache]];
+                                
+                                if (IS_VALID_TILE_IMAGE(tileImage))
+                                {
+                                    // crop
+                                    float cropSize = 1.0 / powf(2.0, (float)currentTileDepth);
+                                    
+                                    CGRect cropBounds = CGRectMake(tileImage.size.width * (nextX - nextTileX),
+                                                                   tileImage.size.height * (nextY - nextTileY),
+                                                                   tileImage.size.width * cropSize,
+                                                                   tileImage.size.height * cropSize);
+                                    
+                                    CGImageRef imageRef = CGImageCreateWithImageInRect([tileImage CGImage], cropBounds);
+                                    tileImage = [UIImage imageWithCGImage:imageRef];
+                                    CGImageRelease(imageRef);
+                                    
+                                    break;
+                                }
+                                else
+                                {
+                                    tileImage = nil;
+                                }
+                                
+                                currentTileDepth++;
+                                currentZoom = zoom - currentTileDepth;
+                            }
+                        }
+                    }
+                    
+                    if (IS_VALID_TILE_IMAGE(tileImage)) {
                         [tileImage drawInRect:CGRectMake(x * rectSize, y * rectSize, rectSize, rectSize)];
+                    }
                 }
             }
 

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -2094,8 +2094,9 @@
 
     UIGraphicsBeginImageContextWithOptions(self.bounds.size, self.opaque, [[UIScreen mainScreen] scale]);
 
-    for (RMMapTiledLayerView *tiledLayerView in _tiledLayersSuperview.subviews)
+    for (RMMapTiledLayerView *tiledLayerView in _tiledLayersSuperview.subviews) {
         tiledLayerView.useSnapshotRenderer = YES;
+    }
 
     [self.layer renderInContext:UIGraphicsGetCurrentContext()];
 

--- a/MapView/Map/RMTileSource.h
+++ b/MapView/Map/RMTileSource.h
@@ -106,7 +106,7 @@
  *  @param tile      The map tile required
  *  @param tileCache The tile cache to obtain the image from
  *
- *  @return The tile image, or NSNull if not cached.
+ *  @return The tile image, or nil if not cached.
  */
 - (UIImage *)cachedImageForTile:(RMTile)tile inCache:(RMTileCache *)tileCache;
 

--- a/MapView/Map/RMTileSource.h
+++ b/MapView/Map/RMTileSource.h
@@ -99,6 +99,17 @@
 *   @return An image to display. */
 - (UIImage *)imageForTile:(RMTile)tile inCache:(RMTileCache *)tileCache;
 
+/**
+ *  Provide an image for a given tile location in the given cache, but don't make
+ *  a network request if it is not already cached.
+ *
+ *  @param tile      The map tile required
+ *  @param tileCache The tile cache to obtain the image from
+ *
+ *  @return The tile image, or NSNull if not cached.
+ */
+- (UIImage *)cachedImageForTile:(RMTile)tile inCache:(RMTileCache *)tileCache;
+
 /** Check if the tile source can provide the requested tile.
  *  @param tile The map tile in question.
  *  @return A Boolean value indicating whether the tile source can provide the requested tile. */


### PR DESCRIPTION
Subclasses should override this method to provide tile images from the cache only, without making any network requests to the tile source. This is used for taking the map snapshot in RMMapView's snapShotRenderer code path in the drawLayer:inContext: method. Previous implementation would block on network before rendering the image. On slow connections, this could result in a significant UI pause before the map image was returned.
