### PR TITLE
Tilesource default images

### DIFF
--- a/MapView/Map/RMAbstractWebMapSource.h
+++ b/MapView/Map/RMAbstractWebMapSource.h
@@ -54,5 +54,13 @@
     @return An array of tile URLs to download, listed bottom to top. */
 - (NSArray *)URLsForTile:(RMTile)tile;
 
+/**
+ *  Adds a default image to be provided for a particular zoom level if the WMTS returns an HTTP 204 (no content) response.
+ *
+ *  @param image The default image to use.
+ *  @param zoom  The zoom level this default image corresponds to.
+ */
+-(void)addDefaultImage:(UIImage *)image forZoomLevel:(NSUInteger)zoom;
+
 
 @end

--- a/MapView/Map/RMAbstractWebMapSource.m
+++ b/MapView/Map/RMAbstractWebMapSource.m
@@ -31,6 +31,21 @@
 #import "RMConfiguration.h"
 
 #define HTTP_404_NOT_FOUND 404
+#define HTTP_204_NO_CONTENT 204
+
+@interface RMAbstractWebMapSource ()
+
+/**
+ *  A dictionary mapping default tile images to zoom levels. This is used if the WMTS returns an HTTP 204 (no content) response.
+ */
+@property (nonatomic, strong) NSMutableDictionary *defaultImagesAtZoomLevels;
+
+/**
+ *  The NSOperation LIFO queue (i.e. stack) used to download tile image data.
+ */
+@property (nonatomic, strong) NSOperationStack *tileDownloadOperationStack;
+
+@end
 
 @implementation RMAbstractWebMapSource
 
@@ -44,6 +59,7 @@
     self.retryCount = RMAbstractWebMapSourceDefaultRetryCount;
     self.requestTimeoutSeconds = RMAbstractWebMapSourceDefaultWaitSeconds;
 
+        _defaultImagesAtZoomLevels = [NSMutableDictionary dictionary];
     return self;
 }
 
@@ -196,13 +212,18 @@
             [request setTimeoutInterval:(self.requestTimeoutSeconds / (CGFloat)self.retryCount)];
             image = [UIImage imageWithData:[NSURLConnection sendBrandedSynchronousRequest:request returningResponse:&response error:nil]];
 
-            if (response.statusCode == HTTP_404_NOT_FOUND)
+            if (response.statusCode == HTTP_404_NOT_FOUND) {
                 break;
+            } else if (response.statusCode == HTTP_204_NO_CONTENT) { // Return default tile image in case HTTP 204 is found
+                image = self.defaultImagesAtZoomLevels[@(tile.zoom)];
+            }
+
         }
     }
 
-    if (image && self.isCacheable)
+    if (image && self.isCacheable) {
         [tileCache addImage:image forTile:tile withCacheKey:[self uniqueTilecacheKey]];
+    }
 
     dispatch_async(dispatch_get_main_queue(), ^(void)
     {
@@ -210,6 +231,10 @@
     });
 
     return image;
+}
+
+-(void)addDefaultImage:(UIImage *)image forZoomLevel:(NSUInteger)zoom {
+    self.defaultImagesAtZoomLevels[@(zoom)] = image;
 }
 
 @end

--- a/MapView/Map/RMAbstractWebMapSource.m
+++ b/MapView/Map/RMAbstractWebMapSource.m
@@ -40,11 +40,6 @@
  */
 @property (nonatomic, strong) NSMutableDictionary *defaultImagesAtZoomLevels;
 
-/**
- *  The NSOperation LIFO queue (i.e. stack) used to download tile image data.
- */
-@property (nonatomic, strong) NSOperationStack *tileDownloadOperationStack;
-
 @end
 
 @implementation RMAbstractWebMapSource
@@ -59,7 +54,7 @@
     self.retryCount = RMAbstractWebMapSourceDefaultRetryCount;
     self.requestTimeoutSeconds = RMAbstractWebMapSourceDefaultWaitSeconds;
 
-        _defaultImagesAtZoomLevels = [NSMutableDictionary dictionary];
+    _defaultImagesAtZoomLevels = [NSMutableDictionary dictionary];
     return self;
 }
 


### PR DESCRIPTION
This provides a mechanism for the web tile source to be configured with default tile images for any zoom level.

These will be returned for display on the map if the tile service returns an HTTP 204 (no content) response, as is the case with, e.g. the OS OpenSpace Pro WMTS.
