### PR TITLE
Request WMTS tiles with NSOperationStack

### DIFF
--- a/MapView/Map/NSOperationStack.h
+++ b/MapView/Map/NSOperationStack.h
@@ -1,0 +1,47 @@
+//
+//  NSOperationStack.h
+//
+//  Version 1.0.2
+//
+//  Created by Nick Lockwood on 28/06/2012.
+//  Copyright (c) 2012 Charcoal Design
+//
+//  Distributed under the permissive zlib License
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/NSOperationStack
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+#import <Foundation/Foundation.h>
+
+
+@interface NSOperationQueue (LIFO)
+
+- (void)addOperationAtFrontOfQueue:(NSOperation *)op;
+- (void)addOperationsAtFrontOfQueue:(NSArray *)ops waitUntilFinished:(BOOL)wait;
+- (void)addOperationAtFrontOfQueueWithBlock:(void (^)(void))block;
+
+@end
+
+
+@interface NSOperationStack : NSOperationQueue
+
+@end

--- a/MapView/Map/NSOperationStack.m
+++ b/MapView/Map/NSOperationStack.m
@@ -1,0 +1,109 @@
+//
+//  NSOperationStack.m
+//
+//  Version 1.0.2
+//
+//  Created by Nick Lockwood on 28/06/2012.
+//  Copyright (c) 2012 Charcoal Design
+//
+//  Distributed under the permissive zlib License
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/NSOperationStack
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+#import "NSOperationStack.h"
+
+
+@implementation NSOperationQueue (LIFO)
+
+- (void)setLIFODependendenciesForOperation:(NSOperation *)op
+{
+    @synchronized(self)
+    {
+        //suspend queue
+        BOOL wasSuspended = [self isSuspended];
+        [self setSuspended:YES];
+        
+        //make op a dependency of all queued ops
+        NSInteger maxOperations = ([self maxConcurrentOperationCount] > 0) ? [self maxConcurrentOperationCount]: INT_MAX;
+        NSArray *operations = [self operations];
+        NSInteger index = [operations count] - maxOperations;
+        if (index >= 0)
+        {
+            NSOperation *operation = operations[index];
+            if (![operation isExecuting])
+            {
+                [operation addDependency:op];
+            }
+        }
+        
+        //resume queue
+        [self setSuspended:wasSuspended];
+    }
+}
+
+- (void)addOperationAtFrontOfQueue:(NSOperation *)op
+{
+    [self setLIFODependendenciesForOperation:op];
+    [self addOperation:op];
+}
+
+- (void)addOperationsAtFrontOfQueue:(NSArray *)ops waitUntilFinished:(BOOL)wait
+{
+    for (NSOperation *op in ops)
+    {
+        [self setLIFODependendenciesForOperation:op];
+    }
+    [self addOperations:ops waitUntilFinished:wait];
+}
+
+- (void)addOperationAtFrontOfQueueWithBlock:(void (^)(void))block
+{
+    [self addOperationAtFrontOfQueue:[NSBlockOperation blockOperationWithBlock:block]];
+}
+
+@end
+
+
+@implementation NSOperationStack
+
+- (void)addOperation:(NSOperation *)op
+{
+    [self setLIFODependendenciesForOperation:op];
+    [super addOperation:op];
+}
+
+- (void)addOperations:(NSArray *)ops waitUntilFinished:(BOOL)wait
+{
+    for (NSOperation *op in ops)
+    {
+        [self setLIFODependendenciesForOperation:op];
+    }
+    [super addOperations:ops waitUntilFinished:wait];
+}
+
+- (void)addOperationWithBlock:(void (^)(void))block
+{
+    [self addOperation:[NSBlockOperation blockOperationWithBlock:block]];
+}
+
+@end

--- a/MapView/Map/RMAbstractWebMapSource.h
+++ b/MapView/Map/RMAbstractWebMapSource.h
@@ -28,7 +28,7 @@
 #import "RMAbstractMercatorTileSource.h"
 #import "RMProjection.h"
 
-#define RMAbstractWebMapSourceDefaultRetryCount  3
+#define RMAbstractWebMapSourceDefaultRetryCount 3
 #define RMAbstractWebMapSourceDefaultWaitSeconds 15.0
 
 /** Abstract class representing a network-based location for retrieving map tiles for display. Developers can create subclasses in order to provide custom web addresses for tile downloads. */
@@ -60,7 +60,15 @@
  *  @param image The default image to use.
  *  @param zoom  The zoom level this default image corresponds to.
  */
--(void)addDefaultImage:(UIImage *)image forZoomLevel:(NSUInteger)zoom;
+- (void)addDefaultImage:(UIImage *)image forZoomLevel:(NSUInteger)zoom;
 
+/**
+ *  Get the default tile image for a given zoom level.
+ *
+ *  @param zoom The zoom level in question.
+ *
+ *  @return The default image for that zoom level, or nil if no image has been defined.
+ */
+- (UIImage *)defaultImageForZoomLevel:(NSUInteger)zoom;
 
 @end

--- a/MapView/Map/RMAbstractWebMapSource.m
+++ b/MapView/Map/RMAbstractWebMapSource.m
@@ -228,8 +228,15 @@
     return image;
 }
 
--(void)addDefaultImage:(UIImage *)image forZoomLevel:(NSUInteger)zoom {
+- (void)addDefaultImage:(UIImage *)image forZoomLevel:(NSUInteger)zoom
+{
     self.defaultImagesAtZoomLevels[@(zoom)] = image;
+}
+
+- (UIImage *)defaultImageForZoomLevel:(NSUInteger)zoom
+{
+    UIImage *image = self.defaultImagesAtZoomLevels[@(zoom)];
+    return image;
 }
 
 @end

--- a/MapView/Map/RMTileCache.m
+++ b/MapView/Map/RMTileCache.m
@@ -498,7 +498,7 @@ static NSMutableDictionary *predicateValues = nil;
 
 - (id <RMTileCache>)memoryCacheWithConfig:(NSDictionary *)cfg
 {
-    NSUInteger capacity = 32;
+    NSUInteger capacity = 64;
 
 	NSNumber *capacityNumber = [cfg objectForKey:@"capacity"];
 	if (capacityNumber != nil)
@@ -533,7 +533,7 @@ static NSMutableDictionary *predicateValues = nil;
     BOOL useCacheDir = NO;
     RMCachePurgeStrategy strategy = RMCachePurgeStrategyFIFO;
 
-    NSUInteger capacity = 1000;
+    NSUInteger capacity = 50000;
     NSUInteger minimalPurge = capacity / 10;
 
     // Defaults

--- a/MapView/Map/RMTileDownloadOperation.h
+++ b/MapView/Map/RMTileDownloadOperation.h
@@ -1,0 +1,19 @@
+//
+//  RMTileDownloadOperation.h
+//  MapView
+//
+//  Created by David Haynes on 31/03/2015.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "RMTile.h"
+#import "RMTileSource.h"
+
+@interface RMTileDownloadOperation : NSOperation
+
+- (id)initWithTile:(RMTile)tile forTileSource:(id <RMTileSource>)source; // usingCache:(RMTileCache *)cache;
+
+@property (nonatomic, strong) NSError *error;
+
+@end

--- a/MapView/Map/RMTileDownloadOperation.h
+++ b/MapView/Map/RMTileDownloadOperation.h
@@ -7,13 +7,37 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "RMTile.h"
 #import "RMTileSource.h"
+#import "RMTile.h"
 
+/**
+ NSOperation subclass that downloads a tile into a tile cache.
+ */
 @interface RMTileDownloadOperation : NSOperation
 
-- (id)initWithTile:(RMTile)tile forTileSource:(id <RMTileSource>)source; // usingCache:(RMTileCache *)cache;
+/**
+ *  Designated initialiser
+ *
+ *  @param tile       The tile to download.
+ *  @param source     The tile source this tile belongs to.
+ *  @param cache      The cache we will be storing this tile in.
+ *  @param retryCount How many times to retry if the request fails.
+ *  @param timeout    How long to wait until timing out the request.
+ *
+ *  @return The tile download operation. N.B. Interaction with UIKit (e.g. to request this tile be
+ *  drawn in a layer) should be done on the main thread, either in a completion block, or using
+ *  NSOperation dependencies.
+ */
+- (id)initWithTile:(RMTile)tile forTileSource:(id<RMTileSource>)source usingCache:(RMTileCache *)cache retryCount:(NSUInteger)retryCount timeout:(NSTimeInterval)timeout;
 
+/**
+ *  If there is an error in the request, this property will contain it.
+ */
 @property (nonatomic, strong) NSError *error;
+
+/**
+ *  The HTTP response from the tile request.
+ */
+@property (nonatomic, strong) NSHTTPURLResponse *response;
 
 @end

--- a/MapView/Map/RMTileDownloadOperation.m
+++ b/MapView/Map/RMTileDownloadOperation.m
@@ -1,0 +1,15 @@
+//
+//  RMTileDownloadOperation.m
+//  MapView
+//
+//  Created by David Haynes on 31/03/2015.
+//
+//
+
+#import "RMTileDownloadOperation.h"
+
+@implementation RMTileDownloadOperation
+
+
+
+@end

--- a/MapView/Map/RMTileDownloadOperation.m
+++ b/MapView/Map/RMTileDownloadOperation.m
@@ -7,9 +7,127 @@
 //
 
 #import "RMTileDownloadOperation.h"
+#import "RMAbstractWebMapSource.h"
+#import "RMConfiguration.h"
+#import "RMTileCache.h"
+
+#define HTTP_404_NOT_FOUND 404
+#define HTTP_204_NO_CONTENT 204
+
+@interface RMTileDownloadOperation ()
+
+@property (nonatomic, assign) RMTile tile;
+@property (nonatomic, strong) id<RMTileSource> tileSource;
+@property (nonatomic, strong) RMTileCache *tileCache;
+@property (nonatomic, assign) NSUInteger retryCount;
+@property (nonatomic, assign) NSTimeInterval requestTimeoutSeconds;
+@property (nonatomic, strong) UIImage *image;
+
+@end
 
 @implementation RMTileDownloadOperation
 
+- (id)initWithTile:(RMTile)tile
+     forTileSource:(id<RMTileSource>)source
+        usingCache:(RMTileCache *)cache
+        retryCount:(NSUInteger)retryCount
+           timeout:(NSTimeInterval)timeout
+{
+    self = [super init];
+    if (self) {
+        NSAssert([source isKindOfClass:[RMAbstractWebMapSource class]], @"Cannot download from non-web tile source");
+        _tile = tile;
+        _tileSource = source;
+        _tileCache = cache;
+        _requestTimeoutSeconds = timeout;
+        _retryCount = retryCount;
+    }
+    return self;
+}
 
+- (void)main
+{
+    if (!self.tileSource)
+    {
+        [self cancel];
+    }
+
+    if ([self isCancelled])
+    {
+        return;
+    }
+
+    if (self.tileSource.isHidden)
+    {
+        [self cancel];
+    }
+
+    UIImage *image = nil;
+
+    self.tile = [self.tileSource.mercatorToTileProjection normaliseTile:self.tile];
+
+    if (self.tileSource.isCacheable)
+    {
+        image = [self.tileCache cachedImage:self.tile withCacheKey:self.tileSource.uniqueTilecacheKey];
+
+        if (image)
+        {
+            self.image = image;
+            return;
+        }
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^(void)
+    {
+        [[NSNotificationCenter defaultCenter] postNotificationName:RMTileRequested object:[NSNumber numberWithUnsignedLongLong:RMTileKey(self.tile)]];
+    });
+
+    NSURL *tileURL = [(RMAbstractWebMapSource *)self.tileSource URLForTile:self.tile];
+
+    if (!tileURL)
+    {
+        return;
+    } else {
+        for (NSUInteger try = 0; image == nil && try < self.retryCount; ++try)
+        {
+            NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:tileURL];
+            request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+            NSError *error = nil;
+            NSHTTPURLResponse *response = self.response;
+            self.image = [UIImage imageWithData:[NSURLConnection sendBrandedSynchronousRequest:request returningResponse:&response error:&error]];
+
+            if (response.statusCode == HTTP_404_NOT_FOUND)
+            {
+                break;
+            } else if (response.statusCode == HTTP_204_NO_CONTENT) { // Return default tile image in case HTTP 204 is found
+                image = [(RMAbstractWebMapSource *)self.tileSource defaultImageForZoomLevel:self.tile.zoom];
+            }
+
+            if (!self.image || error != nil)
+            {
+                if (error != nil)
+                {
+                    self.error = error;
+                } else
+                {
+                    self.error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorUnknown userInfo:nil];
+                }
+                [self cancel];
+            }
+
+            if (self.image && self.tileSource.isCacheable)
+            {
+                if (self.image)
+                {
+                    [self.tileCache addImage:self.image forTile:self.tile withCacheKey:self.tileSource.uniqueTilecacheKey];
+                }
+                dispatch_async(dispatch_get_main_queue(), ^(void)
+                {
+                    [[NSNotificationCenter defaultCenter] postNotificationName:RMTileRetrieved object:[NSNumber numberWithUnsignedLongLong:RMTileKey(self.tile)]];
+                });
+            }
+        }
+    }
+}
 
 @end

--- a/MapView/MapView.xcodeproj/project.pbxproj
+++ b/MapView/MapView.xcodeproj/project.pbxproj
@@ -232,6 +232,14 @@
 		4AF3A6D61AA534DA00CD6FAF /* Mapbox_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 4AF3A6D51AA534DA00CD6FAF /* Mapbox_Prefix.pch */; };
 		96492C400FA8AD3400EBA6D2 /* RMGlobalConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 96492C3F0FA8AD3400EBA6D2 /* RMGlobalConstants.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		B1EB26C610B5D8E6009F8658 /* RMNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = B1EB26C510B5D8E6009F8658 /* RMNotifications.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B31827241ACAAD400041BEEC /* NSOperationStack.h in Headers */ = {isa = PBXBuildFile; fileRef = B31827221ACAAD400041BEEC /* NSOperationStack.h */; };
+		B31827251ACAAD400041BEEC /* NSOperationStack.h in Headers */ = {isa = PBXBuildFile; fileRef = B31827221ACAAD400041BEEC /* NSOperationStack.h */; };
+		B31827261ACAAD400041BEEC /* NSOperationStack.m in Sources */ = {isa = PBXBuildFile; fileRef = B31827231ACAAD400041BEEC /* NSOperationStack.m */; };
+		B31827271ACAAD400041BEEC /* NSOperationStack.m in Sources */ = {isa = PBXBuildFile; fileRef = B31827231ACAAD400041BEEC /* NSOperationStack.m */; };
+		B318272A1ACAB1320041BEEC /* RMTileDownloadOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = B31827281ACAB1320041BEEC /* RMTileDownloadOperation.h */; };
+		B318272B1ACAB1320041BEEC /* RMTileDownloadOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = B31827281ACAB1320041BEEC /* RMTileDownloadOperation.h */; };
+		B318272C1ACAB1320041BEEC /* RMTileDownloadOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B31827291ACAB1320041BEEC /* RMTileDownloadOperation.m */; };
+		B318272D1ACAB1320041BEEC /* RMTileDownloadOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B31827291ACAB1320041BEEC /* RMTileDownloadOperation.m */; };
 		B3B8A78C1AC42BEE0083E33D /* libProj4.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DD97C11516489678007C4652 /* libProj4.a */; };
 		B8474BA40EB40094006A0BC1 /* RMDatabaseCache.h in Headers */ = {isa = PBXBuildFile; fileRef = B8474B980EB40094006A0BC1 /* RMDatabaseCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B8474BA50EB40094006A0BC1 /* RMDatabaseCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B8474B990EB40094006A0BC1 /* RMDatabaseCache.m */; };
@@ -432,6 +440,10 @@
 		4AF3A6D51AA534DA00CD6FAF /* Mapbox_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Mapbox_Prefix.pch; sourceTree = "<group>"; };
 		96492C3F0FA8AD3400EBA6D2 /* RMGlobalConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMGlobalConstants.h; sourceTree = "<group>"; };
 		B1EB26C510B5D8E6009F8658 /* RMNotifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMNotifications.h; sourceTree = "<group>"; };
+		B31827221ACAAD400041BEEC /* NSOperationStack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSOperationStack.h; sourceTree = "<group>"; };
+		B31827231ACAAD400041BEEC /* NSOperationStack.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSOperationStack.m; sourceTree = "<group>"; };
+		B31827281ACAB1320041BEEC /* RMTileDownloadOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMTileDownloadOperation.h; sourceTree = "<group>"; };
+		B31827291ACAB1320041BEEC /* RMTileDownloadOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMTileDownloadOperation.m; sourceTree = "<group>"; };
 		B83E64B60E80E73F001663B6 /* RMPixel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMPixel.h; sourceTree = "<group>"; };
 		B83E64B70E80E73F001663B6 /* RMPixel.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = RMPixel.c; sourceTree = "<group>"; };
 		B83E64D00E80E73F001663B6 /* RMTileCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMTileCache.h; sourceTree = "<group>"; };
@@ -757,6 +769,10 @@
 				16EC85CD133CA6C300219947 /* RMAbstractMercatorTileSource.m */,
 				16EC85CE133CA6C300219947 /* RMAbstractWebMapSource.h */,
 				16EC85CF133CA6C300219947 /* RMAbstractWebMapSource.m */,
+				B31827281ACAB1320041BEEC /* RMTileDownloadOperation.h */,
+				B31827291ACAB1320041BEEC /* RMTileDownloadOperation.m */,
+				B31827221ACAAD400041BEEC /* NSOperationStack.h */,
+				B31827231ACAAD400041BEEC /* NSOperationStack.m */,
 			);
 			name = "Tile Sources";
 			sourceTree = "<group>";
@@ -1005,6 +1021,7 @@
 				4AA8AB061AA0F338007C21F1 /* RMMarker.h in Headers */,
 				4AA8AAC21AA0F322007C21F1 /* RMMapViewDelegate.h in Headers */,
 				4AA8AAC01AA0F322007C21F1 /* RMMapView.h in Headers */,
+				B31827241ACAAD400041BEEC /* NSOperationStack.h in Headers */,
 				4AA8AAC31AA0F322007C21F1 /* RMStaticMapView.h in Headers */,
 				4AA8AAD31AA0F328007C21F1 /* RMMBTilesSource.h in Headers */,
 				4AA8AADF1AA0F328007C21F1 /* RMTileMillSource.h in Headers */,
@@ -1035,6 +1052,7 @@
 				4AA8AADD1AA0F328007C21F1 /* RMBingSource.h in Headers */,
 				4AA8AB5C1AA0F373007C21F1 /* SMCalloutView.h in Headers */,
 				4AA8AB5E1AA0F373007C21F1 /* SMClassicCalloutView.h in Headers */,
+				B318272A1ACAB1320041BEEC /* RMTileDownloadOperation.h in Headers */,
 				4AA8AAC91AA0F328007C21F1 /* RMDBMapSource.h in Headers */,
 				4AA8AB571AA0F367007C21F1 /* FMDB.h in Headers */,
 				4AA8AB511AA0F367007C21F1 /* FMDatabaseAdditions.h in Headers */,
@@ -1085,6 +1103,7 @@
 				DDE357F416522661001DB842 /* RMPolylineAnnotation.h in Headers */,
 				DDE357F816522CD8001DB842 /* RMPolygonAnnotation.h in Headers */,
 				DD1985C1165C5F6400DF667F /* RMTileMillSource.h in Headers */,
+				B31827251ACAAD400041BEEC /* NSOperationStack.h in Headers */,
 				DD63176317D15EB5008CA79B /* RMCircleAnnotation.h in Headers */,
 				DD63175F17D1506D008CA79B /* RMGreatCircleAnnotation.h in Headers */,
 				B8C974220E8A19B2007D16AD /* RMProjection.h in Headers */,
@@ -1103,6 +1122,7 @@
 				1609AF8E14068B09008344B7 /* RMMapOverlayView.h in Headers */,
 				16128CF5148D295300C23C0E /* RMOpenSeaMapSource.h in Headers */,
 				DD8CDB4A14E0507100B73EB9 /* RMMapQuestOSMSource.h in Headers */,
+				B318272B1ACAB1320041BEEC /* RMTileDownloadOperation.h in Headers */,
 				16FFF2CB14E3DBF700A170EC /* RMMapQuestOpenAerialSource.h in Headers */,
 				DD3BEF7915913C55007892D8 /* RMAttributionViewController.h in Headers */,
 				16F3581B15864135003A3AD9 /* RMMapScrollView.h in Headers */,
@@ -1324,6 +1344,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B31827261ACAAD400041BEEC /* NSOperationStack.m in Sources */,
 				4AA8AAD81AA0F328007C21F1 /* RMOpenSeaMapSource.m in Sources */,
 				4AA8AAEB1AA0F332007C21F1 /* RMCacheObject.m in Sources */,
 				4AA8AACC1AA0F328007C21F1 /* RMGenericMapSource.m in Sources */,
@@ -1373,6 +1394,7 @@
 				4AA8AB271AA0F35A007C21F1 /* RMMapScrollView.m in Sources */,
 				4AA8AB211AA0F35A007C21F1 /* RMTileImage.m in Sources */,
 				4AA8AAC61AA0F328007C21F1 /* RMCompositeSource.m in Sources */,
+				B318272C1ACAB1320041BEEC /* RMTileDownloadOperation.m in Sources */,
 				4AA8AACA1AA0F328007C21F1 /* RMDBMapSource.m in Sources */,
 				4AA8AB031AA0F338007C21F1 /* RMQuadTree.m in Sources */,
 				4AA8AB0F1AA0F33D007C21F1 /* RMUserTrackingBarButtonItem.m in Sources */,
@@ -1389,6 +1411,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B31827271ACAAD400041BEEC /* NSOperationStack.m in Sources */,
 				B8C9743F0E8A19B2007D16AD /* RMTileImage.m in Sources */,
 				B8C974400E8A19B2007D16AD /* RMTile.c in Sources */,
 				B8C974410E8A19B2007D16AD /* RMOpenStreetMapSource.m in Sources */,
@@ -1438,6 +1461,7 @@
 				DD56B9591961E23F00706C67 /* FMResultSet.m in Sources */,
 				DD5FA1EC15E2B020004EB6C5 /* RMLoadingTileView.m in Sources */,
 				DD41960216250ED40049E6BA /* RMTileCacheDownloadOperation.m in Sources */,
+				B318272D1ACAB1320041BEEC /* RMTileDownloadOperation.m in Sources */,
 				DD4195CA162356900049E6BA /* RMBingSource.m in Sources */,
 				DD1E3C6F161F954F004FC649 /* SMCalloutView.m in Sources */,
 				DD7C7E39164C894F0021CCA5 /* RMStaticMapView.m in Sources */,

--- a/MapView/MapView.xcodeproj/project.pbxproj
+++ b/MapView/MapView.xcodeproj/project.pbxproj
@@ -665,7 +665,6 @@
 				B8C9740D0E8A196E007D16AD /* Map */,
 				DD932BC2165C294100D69D49 /* Externals */,
 				4AA8AAA71AA0F311007C21F1 /* MapBox-iOS-SDK */,
-				4AA8AAB41AA0F311007C21F1 /* MapBox-iOS-SDKTests */,
 				29B97323FDCFA39411CA2CEA /* Frameworks */,
 				19C28FACFE9D520D11CA2CBB /* Products */,
 			);
@@ -703,13 +702,6 @@
 				4AA8AAA91AA0F311007C21F1 /* Info.plist */,
 			);
 			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		4AA8AAB41AA0F311007C21F1 /* MapBox-iOS-SDKTests */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = "MapBox-iOS-SDKTests";
 			sourceTree = "<group>";
 		};
 		B83E64CE0E80E73F001663B6 /* Tile & Overlay Rendering */ = {


### PR DESCRIPTION
This PR adds NSOperationStack based downloading of tiles.

Handling of duplicate tile URL requests will be in a subsequent PR. At the moment we are dumbly adding all requests to the operation stack.
