### PR TITLE
Separate cache path

### DIFF
--- a/MapView/Map/RMDatabaseCache.m
+++ b/MapView/Map/RMDatabaseCache.m
@@ -242,6 +242,11 @@
 	return cachedImage;
 }
 
+- (UIImage *)cachedImage:(RMTile)tile withCacheKey:(NSString *)cacheKey bypassingMemoryCache:(BOOL)shouldBypassMemoryCache
+{
+    return [self cachedImage:tile withCacheKey:cacheKey];
+}
+
 - (void)addImage:(UIImage *)image forTile:(RMTile)tile withCacheKey:(NSString *)aCacheKey
 {
     [self addDiskCachedImageData:UIImagePNGRepresentation(image) forTile:tile withCacheKey:aCacheKey];

--- a/MapView/Map/RMMemoryCache.m
+++ b/MapView/Map/RMMemoryCache.m
@@ -118,6 +118,11 @@
     return [cachedObject cachedObject];
 }
 
+- (UIImage *)cachedImage:(RMTile)tile withCacheKey:(NSString *)cacheKey bypassingMemoryCache:(BOOL)shouldBypassMemoryCache
+{
+    return [self cachedImage:tile withCacheKey:cacheKey];
+}
+
 - (NSUInteger)capacity
 {
     return _memoryCacheCapacity;

--- a/MapView/Map/RMShape.h
+++ b/MapView/Map/RMShape.h
@@ -78,7 +78,7 @@
 
 @property (nonatomic, assign) BOOL scaleLineWidth;
 @property (nonatomic, assign) CGFloat shadowBlur;
-@property (nonatomic, assign) CGSize shadowOffset;
+@property (assign) CGSize shadowOffset;
 @property (nonatomic, assign) BOOL enableShadow;
 
 /** The bounding box of the shape in the current viewport. */

--- a/MapView/Map/RMTileCache.h
+++ b/MapView/Map/RMTileCache.h
@@ -204,4 +204,13 @@ typedef enum : short {
 *   @return The number of tiles representing the coverage area. */
 - (NSUInteger)tileCountForSouthWest:(CLLocationCoordinate2D)southWest northEast:(CLLocationCoordinate2D)northEast minZoom:(NSUInteger)minZoom maxZoom:(NSUInteger)maxZoom;
 
+/**
+ *  If a cache exists at the specified path, returns it, else creates a new one
+ *
+ *  @param cachePath The path to save the cache at
+ *
+ *  @return An initialised cache
+ */
+- (id<RMTileCache>)databaseCacheAtPath:(NSString *)cachePath;
+
 @end

--- a/MapView/Map/RMTileCache.h
+++ b/MapView/Map/RMTileCache.h
@@ -179,6 +179,18 @@ typedef enum : short {
 *   @param maxZoom The maximum zoom level to cache. */
 - (void)beginBackgroundCacheForTileSource:(id <RMTileSource>)tileSource southWest:(CLLocationCoordinate2D)southWest northEast:(CLLocationCoordinate2D)northEast minZoom:(NSUInteger)minZoom maxZoom:(NSUInteger)maxZoom;
 
+/**
+ *  As above but allows the caller to specify which cache to add the tiles to
+ *
+ *  @param cache      The cache to persist the tiles to
+ *  @param tileSource The tile source from which to retrieve tiles.
+ *  @param southWest  The southwest corner of the geographic area to cache.
+ *  @param northEast  The northeast corner of the geographic area to cache.
+ *  @param minZoom    The minimum zoom level to cache.
+ *  @param maxZoom    The maximum zoom level to cache.
+ */
+- (void)beginBackgroundCacheToCache:(id<RMTileCache>)cache forTileSource:(id<RMTileSource>)tileSource southWest:(CLLocationCoordinate2D)southWest northEast:(CLLocationCoordinate2D)northEast minZoom:(NSUInteger)minZoom maxZoom:(NSUInteger)maxZoom;
+
 /** Cancel any background caching. 
 *
 *   This method returns immediately so as to not block the calling thread. If you wish to be notified of the actual cancellation completion, implement the tileCacheDidCancelBackgroundCache: delegate method. */

--- a/MapView/Map/RMTileCache.m
+++ b/MapView/Map/RMTileCache.m
@@ -428,6 +428,16 @@
     }
 }
 
+- (id<RMTileCache>)databaseCacheAtPath:(NSString *)cachePath
+{
+    RMDatabaseCache *dbCache = [[RMDatabaseCache alloc] initWithDatabase:cachePath];
+    [dbCache setCapacity:0];
+    [dbCache setPurgeStrategy:RMCachePurgeStrategyFIFO];
+    [dbCache setMinimalPurge:0];
+    
+    return dbCache;
+}
+
 - (void)cancelBackgroundCache
 {
     __weak NSOperationQueue *weakBackgroundFetchQueue = _backgroundFetchQueue;

--- a/MapView/Map/RMTileCache.m
+++ b/MapView/Map/RMTileCache.m
@@ -431,7 +431,7 @@
 - (id<RMTileCache>)databaseCacheAtPath:(NSString *)cachePath
 {
     RMDatabaseCache *dbCache = [[RMDatabaseCache alloc] initWithDatabase:cachePath];
-    [dbCache setCapacity:0];
+    [dbCache setCapacity:LONG_MAX];
     [dbCache setPurgeStrategy:RMCachePurgeStrategyFIFO];
     [dbCache setMinimalPurge:0];
     

--- a/MapView/Map/RMTileCache.m
+++ b/MapView/Map/RMTileCache.m
@@ -325,6 +325,11 @@
 
 - (void)beginBackgroundCacheForTileSource:(id <RMTileSource>)tileSource southWest:(CLLocationCoordinate2D)southWest northEast:(CLLocationCoordinate2D)northEast minZoom:(NSUInteger)minZoom maxZoom:(NSUInteger)maxZoom
 {
+    [self beginBackgroundCacheToCache:self forTileSource:tileSource southWest:southWest northEast:northEast minZoom:minZoom maxZoom:maxZoom];
+}
+
+- (void)beginBackgroundCacheToCache:(id<RMTileCache>)cache forTileSource:(id<RMTileSource>)tileSource southWest:(CLLocationCoordinate2D)southWest northEast:(CLLocationCoordinate2D)northEast minZoom:(NSUInteger)minZoom maxZoom:(NSUInteger)maxZoom
+{
     if (self.isBackgroundCaching)
         return;
 
@@ -374,7 +379,7 @@
             {
                 RMTileCacheDownloadOperation *operation = [[RMTileCacheDownloadOperation alloc] initWithTile:RMTileMake((uint32_t)x, (uint32_t)y, zoom)
                                                                                                 forTileSource:_activeTileSource
-                                                                                                   usingCache:self];
+                                                                                                   usingCache:cache];
 
                 __weak RMTileCacheDownloadOperation *internalOperation = operation;
                 __weak RMTileCache *weakSelf = self;

--- a/MapView/Map/RMTileCacheDownloadOperation.h
+++ b/MapView/Map/RMTileCacheDownloadOperation.h
@@ -33,7 +33,7 @@
 
 @interface RMTileCacheDownloadOperation : NSOperation
 
-- (id)initWithTile:(RMTile)tile forTileSource:(id <RMTileSource>)source usingCache:(RMTileCache *)cache;
+- (id)initWithTile:(RMTile)tile forTileSource:(id <RMTileSource>)source usingCache:(id<RMTileCache>)cache;
 
 @property (nonatomic, strong) NSError *error;
 

--- a/MapView/Map/RMTileCacheDownloadOperation.m
+++ b/MapView/Map/RMTileCacheDownloadOperation.m
@@ -33,7 +33,7 @@
 {
     RMTile _tile;
     __weak id <RMTileSource>_source;
-    __weak id<RMTileCache> _cache;
+    id<RMTileCache> _cache;
 }
 
 - (id)initWithTile:(RMTile)tile forTileSource:(id <RMTileSource>)source usingCache:(id<RMTileCache>)cache

--- a/MapView/Map/RMTileCacheDownloadOperation.m
+++ b/MapView/Map/RMTileCacheDownloadOperation.m
@@ -33,10 +33,10 @@
 {
     RMTile _tile;
     __weak id <RMTileSource>_source;
-    __weak RMTileCache *_cache;
+    __weak id<RMTileCache> _cache;
 }
 
-- (id)initWithTile:(RMTile)tile forTileSource:(id <RMTileSource>)source usingCache:(RMTileCache *)cache
+- (id)initWithTile:(RMTile)tile forTileSource:(id <RMTileSource>)source usingCache:(id<RMTileCache>)cache
 {
     if (!(self = [super init]))
         return nil;


### PR DESCRIPTION
This allows us to specify the actual cache to download the tiles to. That will allow us the opportunity to specify individual packages for each offline download we create, giving us control over when we can delete them.
