### PR TITLE
Add property to allow ignoring touches on annotations

### DIFF
--- a/MapView/Map/RMAnnotation.h
+++ b/MapView/Map/RMAnnotation.h
@@ -89,6 +89,9 @@
 @property (nonatomic, assign) RMProjectedRect  projectedBoundingBox;
 @property (nonatomic, assign) BOOL hasBoundingBox;
 
+/** Should this annotation ignore touches and let them pass through to mapview? Defauls value is NO. */
+@property (nonatomic, assign) BOOL ignoresTouches;
+
 /** Whether touch events for the annotation's layer are recognized. Defaults to `YES`. */
 @property (nonatomic, assign, getter=isEnabled) BOOL enabled;
 

--- a/MapView/Map/RMAnnotation.m
+++ b/MapView/Map/RMAnnotation.m
@@ -85,6 +85,7 @@
     self.badgeIcon         = nil;
     self.anchorPoint       = CGPointZero;
     self.hasBoundingBox    = NO;
+    self.ignoresTouches    = NO;
     self.enabled           = YES;
     self.clusteringEnabled = YES;
 

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1885,10 +1885,10 @@
 
 - (void)tapOnAnnotation:(RMAnnotation *)anAnnotation atPoint:(CGPoint)aPoint
 {
-    if (anAnnotation.isEnabled && ! [anAnnotation isEqual:_currentAnnotation])
+    if (anAnnotation.isEnabled && ! [anAnnotation isEqual:_currentAnnotation] && !anAnnotation.ignoresTouches)
         [self selectAnnotation:anAnnotation animated:YES];
 
-    if (_delegateHasTapOnAnnotation && anAnnotation)
+    if (_delegateHasTapOnAnnotation && anAnnotation && !anAnnotation.ignoresTouches)
     {
         [_delegate tapOnAnnotation:anAnnotation onMap:self];
     }
@@ -2029,7 +2029,7 @@
 
 - (void)doubleTapOnAnnotation:(RMAnnotation *)anAnnotation atPoint:(CGPoint)aPoint
 {
-    if (_delegateHasDoubleTapOnAnnotation && anAnnotation)
+    if (_delegateHasDoubleTapOnAnnotation && anAnnotation && !anAnnotation.ignoresTouches)
     {
         [_delegate doubleTapOnAnnotation:anAnnotation onMap:self];
     }
@@ -2041,11 +2041,11 @@
 
 - (void)tapOnLabelForAnnotation:(RMAnnotation *)anAnnotation atPoint:(CGPoint)aPoint
 {
-    if (_delegateHasTapOnLabelForAnnotation && anAnnotation)
+    if (_delegateHasTapOnLabelForAnnotation && anAnnotation && !anAnnotation.ignoresTouches)
     {
         [_delegate tapOnLabelForAnnotation:anAnnotation onMap:self];
     }
-    else if (_delegateHasTapOnAnnotation && anAnnotation)
+    else if (_delegateHasTapOnAnnotation && anAnnotation && !anAnnotation.ignoresTouches)
     {
         [_delegate tapOnAnnotation:anAnnotation onMap:self];
     }
@@ -2058,11 +2058,11 @@
 
 - (void)doubleTapOnLabelForAnnotation:(RMAnnotation *)anAnnotation atPoint:(CGPoint)aPoint
 {
-    if (_delegateHasDoubleTapOnLabelForAnnotation && anAnnotation)
+    if (_delegateHasDoubleTapOnLabelForAnnotation && anAnnotation && !anAnnotation.ignoresTouches)
     {
         [_delegate doubleTapOnLabelForAnnotation:anAnnotation onMap:self];
     }
-    else if (_delegateHasDoubleTapOnAnnotation && anAnnotation)
+    else if (_delegateHasDoubleTapOnAnnotation && anAnnotation && !anAnnotation.ignoresTouches)
     {
         [_delegate doubleTapOnAnnotation:anAnnotation onMap:self];
     }


### PR DESCRIPTION
Adds the option to ignore touches on annotation so we can plot points under the accuracy circle.
