### PR TITLE
Clear sql caches on low mem

### DIFF
--- a/MapView/Map/RMDatabaseCache.m
+++ b/MapView/Map/RMDatabaseCache.m
@@ -422,6 +422,10 @@
     [_writeQueueLock lock];
     [_writeQueue cancelAllOperations];
     [_writeQueueLock unlock];
+
+    [_queue inDatabase:^(FMDatabase *db) {
+        [db clearCachedStatements];
+    }];
 }
 
 @end

--- a/MapView/Map/RMMBTilesSource.m
+++ b/MapView/Map/RMMBTilesSource.m
@@ -328,6 +328,9 @@
 - (void)didReceiveMemoryWarning
 {
     NSLog(@"*** didReceiveMemoryWarning in %@", [self class]);
+    [queue inDatabase:^(FMDatabase *db) {
+        [db clearCachedStatements];
+    }];
 }
 
 - (NSString *)uniqueTilecacheKey


### PR DESCRIPTION
This is an attempt to stop the low-mem crashes seen on OS Maps when there's a lot of offline tile sources loaded. Might need to do something else, but in the short term this seems to make a difference.
