### PR TITLE
Reset cache capacity back to 1000

### DIFF
--- a/MapView/Map/RMTileCache.m
+++ b/MapView/Map/RMTileCache.m
@@ -569,7 +569,7 @@ static NSMutableDictionary *predicateValues = nil;
     BOOL useCacheDir = NO;
     RMCachePurgeStrategy strategy = RMCachePurgeStrategyFIFO;
 
-    NSUInteger capacity = 50000;
+    NSUInteger capacity = 1000;
     NSUInteger minimalPurge = capacity / 10;
 
     // Defaults


### PR DESCRIPTION
Somebody thought 1k tiles seemed like a small amount, so it was raised to 50k. But unfortunately, bearing in mind tiles are anywhere up to 150kb in size, that amounts to a potential cache size of 7.5gb. Ouch. So let's set it back to 1k...
